### PR TITLE
CI: Remove Docker Dependency from Tests Workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,14 +17,6 @@ jobs:
         build_type: [Release, Debug]
     
     steps:
-    - name: Cache apt packages
-      uses: actions/cache@v4
-      with:
-        path: /var/cache/apt
-        key: ${{ runner.os }}-apt-cache-${{ hashFiles('.github/workflows/tests.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-apt-cache-
-
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,49 +8,59 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-ci-image:
-    name: Build CI Image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      image_name: ${{ steps.get_image_name.outputs.image_name }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get image name
-        id: get_image_name
-        run: echo "image_name=ghcr.io/${{ github.repository_owner }}/maplibre-native-slint-ci:${{ github.sha }}" | tr '[:upper:]' '[:lower:]' >> $GITHUB_OUTPUT
-      - name: Build CI image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.get_image_name.outputs.image_name }}
-          target: base
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   test:
     name: Run Tests
-    needs: build-ci-image
     runs-on: ubuntu-latest
-    container: ${{ needs.build-ci-image.outputs.image_name }}
     
     strategy:
       matrix:
         build_type: [Release, Debug]
     
     steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y 
+          build-essential 
+          ccache 
+          cmake 
+          curl 
+          pkg-config 
+          git 
+          libgl1-mesa-dev 
+          libgles2-mesa-dev 
+          libegl1-mesa-dev 
+          libx11-dev 
+          libxrandr-dev 
+          libxinerama-dev 
+          libxcursor-dev 
+          libxi-dev 
+          libxext-dev 
+          xvfb 
+          libbrotli-dev 
+          libcurl4-openssl-dev 
+          libglfw3-dev 
+          libidn2-dev 
+          libjpeg-dev 
+          libnghttp2-dev 
+          libpng-dev 
+          libpsl-dev 
+          libssl-dev 
+          libuv1-dev 
+          libwebp-dev 
+          libzstd-dev 
+          libunistring-dev 
+          meson 
+          zlib1g-dev 
+          gcc 
+          lcov 
+          clang
+
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
     - name: Checkout code
       uses: actions/checkout@v5
       with:
@@ -73,8 +83,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          /root/.cargo/registry
-          /root/.cargo/git
+          ~/.cargo/registry
+          ~/.cargo/git
           build/_deps
         key: ${{ runner.os }}-build-${{ matrix.build_type }}-${{ hashFiles('**/CMakeLists.txt') }}
         restore-keys: |
@@ -83,7 +93,6 @@ jobs:
     
     - name: Configure CMake
       run: |
-        export PATH="/root/.cargo/bin:${PATH}"
         mkdir -p build
         cd build
         cmake .. \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,40 +20,40 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y 
-          build-essential 
-          ccache 
-          cmake 
-          curl 
-          pkg-config 
-          git 
-          libgl1-mesa-dev 
-          libgles2-mesa-dev 
-          libegl1-mesa-dev 
-          libx11-dev 
-          libxrandr-dev 
-          libxinerama-dev 
-          libxcursor-dev 
-          libxi-dev 
-          libxext-dev 
-          xvfb 
-          libbrotli-dev 
-          libcurl4-openssl-dev 
-          libglfw3-dev 
-          libidn2-dev 
-          libjpeg-dev 
-          libnghttp2-dev 
-          libpng-dev 
-          libpsl-dev 
-          libssl-dev 
-          libuv1-dev 
-          libwebp-dev 
-          libzstd-dev 
-          libunistring-dev 
-          meson 
-          zlib1g-dev 
-          gcc 
-          lcov 
+        sudo apt-get install -y \
+          build-essential \
+          ccache \
+          cmake \
+          curl \
+          pkg-config \
+          git \
+          libgl1-mesa-dev \
+          libgles2-mesa-dev \
+          libegl1-mesa-dev \
+          libx11-dev \
+          libxrandr-dev \
+          libxinerama-dev \
+          libxcursor-dev \
+          libxi-dev \
+          libxext-dev \
+          xvfb \
+          libbrotli-dev \
+          libcurl4-openssl-dev \
+          libglfw3-dev \
+          libidn2-dev \
+          libjpeg-dev \
+          libnghttp2-dev \
+          libpng-dev \
+          libpsl-dev \
+          libssl-dev \
+          libuv1-dev \
+          libwebp-dev \
+          libzstd-dev \
+          libunistring-dev \
+          meson \
+          zlib1g-dev \
+          gcc \
+          lcov \
           clang
 
     - name: Install Rust

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,14 @@ jobs:
         build_type: [Release, Debug]
     
     steps:
+    - name: Cache apt packages
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt
+        key: ${{ runner.os }}-apt-cache-${{ hashFiles('.github/workflows/tests.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-cache-
+
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -56,10 +64,8 @@ jobs:
           lcov \
           clang
 
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+    - name: Setup Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Checkout code
       uses: actions/checkout@v5


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow configuration for running tests. The main change is the removal of the custom Docker-based CI image build and the switch to installing all dependencies directly in the runner environment. This simplifies the workflow and makes it easier to maintain. The cache paths and Rust installation steps have also been updated accordingly.

Workflow simplification:

* Removed the `build-ci-image` job and all related Docker build and container steps, switching the test job to run directly on the GitHub Actions runner instead of inside a custom Docker container.

Dependency management:

* Added explicit steps to install all required build and test dependencies using `apt-get` in the test job, ensuring the environment is prepared without relying on a pre-built Docker image.
* Added a step to install Rust using `rustup`, and updated the `PATH` to include Cargo's bin directory.

Caching improvements:

* Updated cache paths from `/root/.cargo/*` to `~/.cargo/*` to match the new environment where dependencies are installed directly on the runner.

Other adjustments:

* Removed the manual export of Cargo's bin directory from the CMake configuration step, as the `PATH` is now set globally after Rust installation.

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (if applicable)

## Screenshots

N/A
