### PR TITLE
feat: Add fly to buttons and enable animation rendering

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -59,6 +59,12 @@ int main(int argc, char** argv) {
             slint_map_libre->handle_wheel_zoom(x, y, dy);
         });
 
+    main_window->global<MapAdapter>().on_fly_to(
+        [=](const slint::SharedString &location) {
+            slint_map_libre->fly_to(
+                std::string(location.data(), location.size()));
+        });
+
     // Initialize/resize MapLibre to match the map image area
     main_window->on_map_size_changed([=]() {
         const auto s = main_window->get_map_size();

--- a/examples/map_window.slint
+++ b/examples/map_window.slint
@@ -8,7 +8,7 @@ export struct Size {
 
 export global MapAdapter {
     in-out property <image> map_texture;
-    callback render_map();
+    callback tick_map_loop();
     callback mouse_press(float, float);
     callback mouse_release(float, float);
     callback mouse_move(float, float, bool);
@@ -43,10 +43,10 @@ export component MapWindow inherits Window {
     ];
 
     Timer {
-        interval: 200ms;
+        interval: 16ms;
         running: true;
         triggered => {
-            MapAdapter.render_map();
+            MapAdapter.tick_map_loop();
         }
     }
 

--- a/examples/map_window.slint
+++ b/examples/map_window.slint
@@ -1,4 +1,4 @@
-import { StandardButton, VerticalBox, ComboBox } from "std-widgets.slint";
+import { Button, VerticalBox, ComboBox, HorizontalBox } from "std-widgets.slint";
 
 // Define a struct to hold window size
 export struct Size {
@@ -15,6 +15,7 @@ export global MapAdapter {
     callback style_changed(string);
     callback double_click_with_shift(float, float, bool);
     callback wheel_zoom(float, float, float);
+    callback fly_to(string);
 }
 
 export component MapWindow inherits Window {
@@ -50,10 +51,30 @@ export component MapWindow inherits Window {
     }
 
     VerticalBox {
-        ComboBox {
-            model: root.style_urls;
-            selected(url) => {
-                MapAdapter.style_changed(url);
+        HorizontalBox {
+            ComboBox {
+                model: root.style_urls;
+                selected(url) => {
+                    MapAdapter.style_changed(url);
+                }
+            }
+            Button {
+                text: "Paris";
+                clicked => {
+                    MapAdapter.fly_to("paris");
+                }
+            }
+            Button {
+                text: "New York";
+                clicked => {
+                    MapAdapter.fly_to("new_york");
+                }
+            }
+            Button {
+                text: "Tokyo";
+                clicked => {
+                    MapAdapter.fly_to("tokyo");
+                }
             }
         }
         map := Image {

--- a/src/slint_maplibre.cpp
+++ b/src/slint_maplibre.cpp
@@ -274,3 +274,28 @@ void SlintMapLibre::run_map_loop() {
         run_loop->runOnce();
     }
 }
+
+void SlintMapLibre::fly_to(const std::string& location) {
+    if (!map)
+        return;
+
+    mbgl::CameraOptions cameraOptions;
+    if (location == "paris") {
+        cameraOptions.center = mbgl::LatLng{48.8566, 2.3522};
+    } else if (location == "new_york") {
+        cameraOptions.center = mbgl::LatLng{40.7128, -74.0060};
+    } else if (location == "tokyo") {
+        cameraOptions.center = mbgl::LatLng{35.6895, 139.6917};
+    }
+    cameraOptions.zoom = 12.0;
+
+    mbgl::AnimationOptions animationOptions{std::chrono::seconds(2)};
+    // Ease from slow to fast and then slow again
+    animationOptions.easing.emplace(0.25, 0.46, 0.45, 0.94);
+
+    map->flyTo(cameraOptions, animationOptions);
+
+    if (m_renderCallback) {
+        slint::invoke_from_event_loop(m_renderCallback);
+    }
+}

--- a/src/slint_maplibre.hpp
+++ b/src/slint_maplibre.hpp
@@ -29,6 +29,7 @@ public:
     void handle_double_click(float x, float y, bool shift);
     void handle_wheel_zoom(float x, float y, float dy);
     void setStyleUrl(const std::string& url);
+    void fly_to(const std::string& location);
 
     // Manually drive the map's run loop
     void run_map_loop();

--- a/src/slint_maplibre.hpp
+++ b/src/slint_maplibre.hpp
@@ -2,18 +2,58 @@
 
 #include <atomic>
 #include <functional>
-#include <mbgl/gfx/headless_frontend.hpp>
-#include <mbgl/map/map.hpp>
-#include <mbgl/map/map_observer.hpp>
-#include <mbgl/map/map_options.hpp>
-#include <mbgl/storage/resource_options.hpp>
-#include <mbgl/util/run_loop.hpp>
 #include <memory>
 #include <slint.h>
 #include <string>
 
-#include "../platform/custom_file_source.hpp"
+// All required MapLibre headers
+#include <mbgl/gfx/headless_frontend.hpp>
+#include <mbgl/map/map.hpp>
+#include <mbgl/map/map_observer.hpp>
+#include <mbgl/map/map_options.hpp>
+#include <mbgl/renderer/renderer_observer.hpp>
+#include <mbgl/storage/resource_options.hpp>
+#include <mbgl/util/run_loop.hpp>
 
+// Custom file source is implemented, but not required for core rendering
+// paths used here. We avoid constructing it eagerly to reduce startup
+// complexity.
+
+// --- No-op Observer for safe shutdown ---
+class NoopRendererObserver final : public mbgl::RendererObserver {
+public:
+    void onInvalidate() override {
+    }
+    void onDidFinishRenderingFrame(RenderMode, bool, bool) override {
+    }
+};
+
+// --- Renderer Observer ---
+// Receives repaint requests from MapLibre and forwards them to the Slint event
+// loop. This class is now fully defined here to resolve compilation issues.
+class SlintRendererObserver : public mbgl::RendererObserver {
+public:
+    explicit SlintRendererObserver(std::function<void()> notifyRepaint)
+        : m_notifyRepaint(std::move(notifyRepaint)) {
+    }
+
+    void onInvalidate() override {
+        if (m_notifyRepaint)
+            m_notifyRepaint();
+    }
+
+    void onDidFinishRenderingFrame(RenderMode mode, bool needsRepaint,
+                                   bool placementChanged) override {
+        if (needsRepaint || placementChanged) {
+            onInvalidate();
+        }
+    }
+
+private:
+    std::function<void()> m_notifyRepaint;
+};
+
+// --- Main MapLibre Integration Class ---
 class SlintMapLibre : public mbgl::MapObserver {
 public:
     SlintMapLibre();
@@ -33,6 +73,13 @@ public:
 
     // Manually drive the map's run loop
     void run_map_loop();
+    void tick_animation();
+
+    // Repaint signaling consumed by UI thread (timer)
+    bool take_repaint_request();
+    void request_repaint();
+    bool consume_forced_repaint();
+    void arm_forced_repaint_ms(int ms);
 
     // MapObserver implementation
     void onWillStartLoadingMap() override;
@@ -42,11 +89,18 @@ public:
                              const std::string& what) override;
 
 private:
-    std::unique_ptr<mbgl::Map> map;
-    std::unique_ptr<mbgl::HeadlessFrontend> frontend;
-    std::unique_ptr<mbgl::CustomFileSource> file_source;
-    std::unique_ptr<mbgl::util::RunLoop> run_loop;
+    // Declaration order matters for destruction order (bottom-up).
+    // The observer must outlive the frontend.
+    std::unique_ptr<mbgl::util::RunLoop> run_loop;  // created in initialize()
     std::function<void()> m_renderCallback;
+
+    // Observer and frontend must be declared before the map.
+    // The observer must be declared before the frontend to ensure it's
+    // destroyed after.
+    std::unique_ptr<SlintRendererObserver> m_renderer_observer;
+    NoopRendererObserver m_noop_observer;  // For safe shutdown
+    std::unique_ptr<mbgl::HeadlessFrontend> frontend;
+    std::unique_ptr<mbgl::Map> map;
 
     int width = 0;
     int height = 0;
@@ -55,7 +109,25 @@ private:
     double min_zoom = 0.0;
     double max_zoom = 22.0;
 
-    // Style loading state management
+    // Style/loading state management
     std::atomic<bool> style_loaded{false};
     std::atomic<bool> map_idle{false};
+    std::atomic<bool> repaint_needed{false};
+
+    bool fallback_style_applied{false};
+    std::atomic<int> forced_repaint_frames{0};
+
+    struct CustomAnim {
+        bool active = false;
+        mbgl::LatLng start_center{};
+        mbgl::LatLng target_center{};
+        double start_zoom = 0.0;
+        double target_zoom = 0.0;
+        double mid_zoom = 0.0;
+        double mid_ratio = 0.35;  // fraction of duration for zoom-out phase
+        double center_hold_ratio =
+            0.2;  // hold center early to emphasize zoom-out
+        std::chrono::steady_clock::time_point start_time{};
+        int duration_ms = 0;
+    } custom_anim;
 };


### PR DESCRIPTION
## Description

This pull request introduces significant improvements to the MapLibre and Slint integration, focusing on more robust rendering, event handling, and user interaction. The main changes include refactoring the rendering loop for better UI responsiveness and animation support, adding new user controls (such as "fly to" buttons), and improving error handling and debugging output.

**Rendering and Event Loop Refactor:**

* Changed the rendering loop to use a new `tick_map_loop` callback, enabling smoother animations and better separation between the MapLibre event loop and rendering logic. The timer interval was reduced from 200ms to 16ms for more responsive updates. (`examples/main.cpp`, `examples/map_window.slint`) [[1]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6L18-R39) [[2]](diffhunk://#diff-5618f141379ce84055686ca68d7bf7d79cf7c797beb53033ec136787ddb16c98L11-R18) [[3]](diffhunk://#diff-5618f141379ce84055686ca68d7bf7d79cf7c797beb53033ec136787ddb16c98L45-R79)
* Updated the MapLibre initialization to defer the creation of the event loop until the UI is ready, reducing potential issues with early event handling. (`src/slint_maplibre.cpp`)

**User Interaction and Controls:**

* Added "fly to" buttons in the UI, allowing users to quickly move the map to Paris, New York, or Tokyo. This is supported by a new `fly_to` callback in the global adapter. (`examples/map_window.slint`, `examples/main.cpp`) [[1]](diffhunk://#diff-5618f141379ce84055686ca68d7bf7d79cf7c797beb53033ec136787ddb16c98L45-R79) [[2]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6R70-R75)

**Error Handling and Debugging:**

* Improved error handling for style loading: if the remote style fails to load, a fallback local style is applied. (`src/slint_maplibre.cpp`)
* Enhanced logging throughout the application, including startup and shutdown messages, rendering debug output, and exception handling in `main`. (`examples/main.cpp`, `src/slint_maplibre.cpp`) [[1]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6R9) [[2]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6R92-R102) [[3]](diffhunk://#diff-160ac6d480b3255796846183791bc6de8cd8e4856eeaa4a5693daf33548657dbL142-L157)

**Rendering Pipeline Improvements:**

* Improved the rendering pipeline to ensure a valid backend scope for rendering and to use `renderOnce` and `readStillImage` for frame capture, which increases compatibility and reliability across platforms. (`src/slint_maplibre.cpp`)

**Animation and Responsiveness:**

* Switched the map mode from static to continuous to support animations and interactive features. (`src/slint_maplibre.cpp`)
* Updated event handlers to use repaint requests and forced repaint timers for smoother UI updates after user interactions. (`src/slint_maplibre.cpp`) [[1]](diffhunk://#diff-160ac6d480b3255796846183791bc6de8cd8e4856eeaa4a5693daf33548657dbL98-R125) [[2]](diffhunk://#diff-160ac6d480b3255796846183791bc6de8cd8e4856eeaa4a5693daf33548657dbL218-R264) [[3]](diffhunk://#diff-160ac6d480b3255796846183791bc6de8cd8e4856eeaa4a5693daf33548657dbL233-R277) [[4]](diffhunk://#diff-160ac6d480b3255796846183791bc6de8cd8e4856eeaa4a5693daf33548657dbL255-R297)

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (if applicable)

## Screenshots


![25c39c901c0f18bc5b588a5bc4c3aac0](https://github.com/user-attachments/assets/6b32f77a-1e84-4bb2-9c76-526dc92892a7)

