### PR TITLE
feat: update build guides and configuration files

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,4 @@
+
+build/*
+build-ninja/*
+vendor/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # CMake
 !docs/build
 build/
+build-*/
 build-ninja/
+
 .cache
 CMakeCache.txt
 CMakeFiles/
@@ -9,6 +11,7 @@ CMakeScripts/
 cmake_install.cmake
 install_manifest.txt
 compile_commands.json
+.DS_Store
 
 # Binaries
 *.exe
@@ -31,3 +34,4 @@ vendor/
 *.log
 
 cache.sqlite
+cache.sqlite-journal

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 22.18.0
+rust stable

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,9 @@
     "unittests",
     "unpremult",
     "vcpkg"
-  ]
+  ],
+  "files.associations": {
+    "__tree": "cpp",
+    "map": "cpp"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This project demonstrates the integration of [MapLibre Native](https://github.co
 
 For detailed build instructions, see the platform-specific guides:
 
-- **Linux**: [Ubuntu 24.04 Build Guide](docs/build/Linux_Ubuntu_24.md)
-- **macOS**: [macOS Build Guide](docs/build/macOS_Apple_Silicon.md)
-- **Windows**: [Windows Build Guide](docs/build/Windows.md) _(coming soon)_
+- **Linux**: [Ubuntu 24.04 Build Guide](docs/build_guides/Linux_Ubuntu_24.md)
+- **macOS**: [macOS Build Guide](docs/build_guides/macOS_Apple_Silicon.md)
+- **Windows**: [Windows Build Guide](docs/build_guides/Windows_11.md)
 
 ## Screenshots
 

--- a/docs/build_guides/Windows_11.md
+++ b/docs/build_guides/Windows_11.md
@@ -80,7 +80,7 @@ cmake -S . -B build-ninja -G "Ninja" ^
 ## 5) Build
 
 ```bat
-cmake --build build-ninja
+cmake --build build-ninja -j
 ```
 
 ---


### PR DESCRIPTION
## Description

This pull request introduces several improvements to the project's configuration, documentation, and development workflow. The most important changes include updates to documentation for platform-specific build guides, enhancements to development environment settings, and the addition of configuration files for ignoring build artifacts and specifying tool versions.

**Documentation updates:**

* Updated the `README.md` to point to new locations for platform-specific build guides and replaced the Windows build guide link with the correct filename.
* Updated the Windows build instructions to use parallel builds with the `-j` flag for faster compilation.

**Development environment improvements:**

* Added file associations for `__tree` and `map` as C++ files in `.vscode/settings.json` to improve editor support.

**Configuration and tooling:**

* Added `.clang-format-ignore` to exclude `build/*`, `build-ninja/*`, and `vendor/*` from formatting checks.
* Added `rust stable` to `.tool-versions` to specify Rust as a required tool for the project.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (if applicable)

## Screenshots

(If applicable, screenshots of the changes)
