### PR TITLE
Improve pan operation with direct pointer event handling

### DIFF
--- a/examples/map_window.slint
+++ b/examples/map_window.slint
@@ -81,39 +81,21 @@ export component MapWindow inherits Window {
             source: MapAdapter.map_texture;
 
             touch := TouchArea {
-                // Keep internal dragging state to control cursor explicitly
-                property <bool> dragging: false;
-                // Start drag only after a small threshold to avoid accidental map moves
-                property <length> drag-threshold: 4px;
                 // Track last seen Shift modifier state from pointer events
                 property <bool> last-shift: false;
-                mouse-cursor: self.dragging ? grabbing : grab;
+                mouse-cursor: self.pressed ? grabbing : grab;
 
-                // Handle press/drag via moved + internal state
-                moved => {
-                    // Only engage dragging after pointer moved beyond threshold from press point
-                    if (!self.dragging && self.pressed) {
-                        if ( (self.mouse-x - self.pressed-x >= self.drag-threshold)
-                             || (self.pressed-x - self.mouse-x >= self.drag-threshold)
-                             || (self.mouse-y - self.pressed-y >= self.drag-threshold)
-                             || (self.pressed-y - self.mouse-y >= self.drag-threshold) ) {
-                            self.dragging = true;
-                            // Initialize drag at current position to avoid initial jump
-                            MapAdapter.mouse_press(self.mouse-x / 1px, self.mouse-y / 1px);
-                        }
-                    }
-                    if (self.dragging && self.pressed) {
-                        MapAdapter.mouse_move(self.mouse-x / 1px, self.mouse-y / 1px, true);
-                    }
-                    if (self.dragging && !self.pressed) {
-                        MapAdapter.mouse_release(self.mouse-x / 1px, self.mouse-y / 1px);
-                        self.dragging = false;
-                    }
-                }
-
-                // Track modifiers from pointer events so we can use them in double-clicked
+                // Handle all pointer events properly
                 pointer-event(e) => {
                     self.last-shift = e.modifiers.shift;
+
+                    if (e.kind == PointerEventKind.down) {
+                        MapAdapter.mouse_press(self.mouse-x / 1px, self.mouse-y / 1px);
+                    } else if (e.kind == PointerEventKind.up) {
+                        MapAdapter.mouse_release(self.mouse-x / 1px, self.mouse-y / 1px);
+                    } else if (e.kind == PointerEventKind.move && self.pressed) {
+                        MapAdapter.mouse_move(self.mouse-x / 1px, self.mouse-y / 1px, true);
+                    }
                 }
 
                 // Double-click to zoom in (backend handles clamping)

--- a/src/slint_maplibre_headless.cpp
+++ b/src/slint_maplibre_headless.cpp
@@ -286,8 +286,9 @@ void SlintMapLibre::handle_mouse_release(float x, float y) {
 void SlintMapLibre::handle_mouse_move(float x, float y, bool pressed) {
     if (pressed) {
         mbgl::Point<double> current_pos = {x, y};
+        mbgl::Point<double> delta = current_pos - last_pos;
         // Move the map along with the pointer movement (dragging behavior)
-        map->moveBy(current_pos - last_pos);
+        map->moveBy(delta);
         last_pos = current_pos;
         map->triggerRepaint();
     }


### PR DESCRIPTION
This change simplifies mouse/touch handling by using pointer-event directly instead of the moved event with dragging state management.

Changes:
- Backend: Extract delta calculation explicitly for clarity
- Frontend: Replace moved-based dragging with pointer-event handling
- Remove drag threshold and dragging state (unnecessary complexity)
- Simplify mouse cursor logic

## Description

(A brief description of the changes in this pull request)

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (if applicable)

## Screenshots

(If applicable, screenshots of the changes)
